### PR TITLE
Fix: Refactor Changes on Sequelize Functions due to PostgreSQL Database

### DIFF
--- a/backend/controllers/dashboardController.js
+++ b/backend/controllers/dashboardController.js
@@ -19,8 +19,8 @@ const dashboardController = {
             where: {
               transactionDate: {
                 [Op.and]: [
-                  sequelize.where(sequelize.fn('MONTH', sequelize.col('Transaction.transactionDate')), month),
-                  sequelize.where(sequelize.fn('YEAR', sequelize.col('Transaction.transactionDate')), year)
+                    [sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Transaction\".\"transactionDate\"")), 'month'],
+                    [sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Transaction\".\"transactionDate\"")), 'year'],
                 ]
               },
               status: {
@@ -46,8 +46,8 @@ const dashboardController = {
             where: {
               date: {
                 [Op.and]: [
-                  sequelize.where(sequelize.fn('MONTH', sequelize.col('Expense.date')), month),
-                  sequelize.where(sequelize.fn('YEAR', sequelize.col('Expense.date')), year)
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Expense\".\"date\"")), month),
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Expense\".\"date\"")), year)
                 ]
               },
               status: {
@@ -95,8 +95,8 @@ const dashboardController = {
       // Get daily income from non-refunded test details in non-cancelled transactions, excluding balance amounts
       const dailyData = await TestDetails.findAll({
         attributes: [
-          [sequelize.fn('DAY', sequelize.col('Transaction.transactionDate')), 'day'],
-          [sequelize.fn('DAYNAME', sequelize.col('Transaction.transactionDate')), 'dayName'],
+          [sequelize.fn('EXTRACT', sequelize.literal("DAY FROM \"Transaction\".\"transactionDate\"")), 'day'],
+          sequelize.fn('TO_CHAR', sequelize.col('Transaction.transactionDate'), 'Day'),
           [sequelize.fn('SUM', sequelize.literal('TestDetails.discountedPrice - TestDetails.balanceAmount')), 'totalAmount']
         ],
         include: [
@@ -105,8 +105,8 @@ const dashboardController = {
             where: {
               transactionDate: {
                 [Op.and]: [
-                  sequelize.where(sequelize.fn('MONTH', sequelize.col('Transaction.transactionDate')), month),
-                  sequelize.where(sequelize.fn('YEAR', sequelize.col('Transaction.transactionDate')), year)
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Transaction\".\"transactionDate\"")), month),
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Transaction\".\"transactionDate\"")), year)
                 ]
               },
               status: {
@@ -121,8 +121,9 @@ const dashboardController = {
             [Op.ne]: 'refunded'
           }
         },
-        group: [sequelize.fn('DAY', sequelize.col('Transaction.transactionDate')), sequelize.fn('DAYNAME', sequelize.col('Transaction.transactionDate'))],
-        order: [[sequelize.fn('DAY', sequelize.col('Transaction.transactionDate')), 'ASC']],
+        group:  [sequelize.fn('EXTRACT', sequelize.literal("DAY FROM \"Transaction\".\"transactionDate\"")), 'day'],
+        dayName: sequelize.fn('TO_CHAR', sequelize.col('Transaction.transactionDate'), 'Day'),
+        order: [sequelize.fn('EXTRACT', sequelize.literal("DAY FROM \"Transaction\".\"transactionDate\"")), 'day'],
         raw: true
       });
 
@@ -160,8 +161,8 @@ const dashboardController = {
             where: {
               date: {
                 [Op.and]: [
-                  sequelize.where(sequelize.fn('MONTH', sequelize.col('Expense.date')), month),
-                  sequelize.where(sequelize.fn('YEAR', sequelize.col('Expense.date')), year)
+                 sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Expense\".\"date\"")), month),
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Expense\".\"date\"")), year)
                 ]
               },
               status: {
@@ -188,8 +189,8 @@ const dashboardController = {
             where: {
               date: {
                 [Op.and]: [
-                  sequelize.where(sequelize.fn('MONTH', sequelize.col('Expense.date')), month),
-                  sequelize.where(sequelize.fn('YEAR', sequelize.col('Expense.date')), year)
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Expense\".\"date\"")), month),
+                  sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Expense\".\"date\"")), year)
                 ]
               },
               status: {
@@ -269,8 +270,8 @@ const dashboardController = {
               where: {
                 transactionDate: {
                   [Op.and]: [
-                    sequelize.where(sequelize.fn('MONTH', sequelize.col('Transaction.transactionDate')), month),
-                    sequelize.where(sequelize.fn('YEAR', sequelize.col('Transaction.transactionDate')), year)
+                    [sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Transaction\".\"transactionDate\"")), 'month'],
+                    [sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Transaction\".\"transactionDate\"")), 'year'],
                   ]
                 },
                 status: {
@@ -296,8 +297,8 @@ const dashboardController = {
               where: {
                 date: {
                   [Op.and]: [
-                    sequelize.where(sequelize.fn('MONTH', sequelize.col('Expense.date')), month),
-                    sequelize.where(sequelize.fn('YEAR', sequelize.col('Expense.date')), year)
+                    [sequelize.fn('EXTRACT', sequelize.literal("MONTH FROM \"Transaction\".\"transactionDate\"")), 'month'],
+                    [sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Transaction\".\"transactionDate\"")), 'year'],
                   ]
                 },
                 status: {


### PR DESCRIPTION
# ⚒ What's Changed?

Change from:
sequelize.where(sequelize.fn('YEAR', sequelize.col('Expense.date')), year)

To:
sequelize.where(sequelize.fn('EXTRACT', sequelize.literal("YEAR FROM \"Expense\".\"date\"")), year)

Change from:
sequelize.fn('DAY', sequelize.col('Transaction.transactionDate'))

To:
sequelize.fn('EXTRACT', sequelize.literal("DAY FROM \"Transaction\".\"transactionDate\""))

 Change from:
sequelize.fn('DAYNAME', sequelize.col('Transaction.transactionDate'))

To:
sequelize.fn('TO_CHAR', sequelize.col('Transaction.transactionDate'), 'Day')