### PR TITLE
Add: 20% Discount on PWD and Senior Citizen on Transaction

### DIFF
--- a/backend/controllers/transactionController.js
+++ b/backend/controllers/transactionController.js
@@ -58,24 +58,17 @@ exports.createTransaction = async (req, res) => {
       const cashAmount = parseFloat(item.cashAmount) || 0;
       const gCashAmount = parseFloat(item.gCashAmount) || 0;
       const balanceAmount = parseFloat(item.balanceAmount) || 0;
-      totalAmount += originalPrice;
+    
+      // Use the already calculated values from frontend
+      totalAmount += discountedPrice; 
       totalDiscountAmount += (originalPrice - discountedPrice);
       totalCashAmount += cashAmount;
       totalGCashAmount += gCashAmount;
-      totalBalanceAmount += balanceAmount;
+      totalBalanceAmount += balanceAmount;  
     });
 
-    // Apply 20% discount for PWD or Senior Citizen
-    const normalizedIdType = (idType || '').trim().toLowerCase();
-    if (normalizedIdType === 'person with disability' || normalizedIdType === 'senior citizen') {
-      const discount = totalAmount * 0.2;
-      totalDiscountAmount = discount; 
-      totalAmount = totalAmount - discount;
-      totalCashAmount = totalCashAmount * 0.8;
-      totalGCashAmount = totalGCashAmount * 0.8;
-      totalBalanceAmount = totalBalanceAmount * 0.8;
-    }
-
+    // Note: PWD/Senior Citizen discount is already applied in frontend calculations
+    // No need to apply additional discount here
     // Generate sequential MC number if not provided
     let generatedMcNo;
     if (mcNo) {
@@ -241,8 +234,8 @@ exports.getAllTransactions = async (req, res) => {
     
     includes.push({
       model: TestDetails,
-      attributes: ['testName', 'departmentId', 'originalPrice', 'discountPercentage', 
-                  'discountedPrice', 'cashAmount', 'gCashAmount', 'balanceAmount']
+      attributes: ['testDetailId', 'testName', 'departmentId', 'originalPrice', 'discountPercentage', 
+                  'discountedPrice', 'cashAmount', 'gCashAmount', 'balanceAmount', 'status']
     });
     
     if (includeDetails === 'true') {
@@ -443,7 +436,8 @@ exports.updateTransaction = async (req, res) => {
       idNumber,
       userId,
       testDetails,
-      isRefundProcessing
+      isRefundProcessing,
+      excessRefunds
     } = req.body;
     
     const transaction = await Transaction.findByPk(id);
@@ -471,13 +465,16 @@ exports.updateTransaction = async (req, res) => {
 
     await transaction.update(updateData, { transaction: t });
 
+    // Initialize variables outside the scope to avoid reference errors
+    let totalCashAmount = 0;
+    let totalGCashAmount = 0;
+    let totalBalanceAmount = 0;
+    let totalRefundAmount = 0;
+    let totalDiscountAmount = 0;
+    let totalExcessRefundAmount = 0;
+
     // Update test details if provided
     if (testDetails && Array.isArray(testDetails)) {
-      let totalCashAmount = 0;
-      let totalGCashAmount = 0;
-      let totalBalanceAmount = 0;
-      let totalRefundAmount = 0;
-      let totalDiscountAmount = 0;
       
       // Process each test detail and update department revenue
       for (const detail of testDetails) {
@@ -592,6 +589,13 @@ exports.updateTransaction = async (req, res) => {
         }
       }
       
+      // Calculate total excess refunds from overpayment adjustments
+      if (excessRefunds && typeof excessRefunds === 'object') {
+        totalExcessRefundAmount = Object.values(excessRefunds).reduce((sum, amount) => {
+          return sum + (parseFloat(amount) || 0);
+        }, 0);
+      }
+      
       // Update transaction totals
       await transaction.update({
         totalCashAmount,
@@ -602,6 +606,8 @@ exports.updateTransaction = async (req, res) => {
           ...JSON.parse(transaction.metadata || '{}'),
           totalRefundAmount,
           totalDiscountAmount,
+          excessRefundAmount: totalExcessRefundAmount,
+          excessRefunds: excessRefunds || {},
           refundProcessed: isRefundProcessing ? true : false,
           updatedAt: new Date().toISOString()
         })
@@ -609,12 +615,24 @@ exports.updateTransaction = async (req, res) => {
     }
 
     // Log activity
+    let activityDetails = `Updated transaction details for ${transaction.firstName} ${transaction.lastName}`;
+    
+    // Add excess refund information to activity log if present
+    if (totalExcessRefundAmount > 0) {
+      activityDetails += `. Excess refund amount: ₱${totalExcessRefundAmount.toFixed(2)} due to payment adjustments`;
+    }
+    
     await ActivityLog.create({
       action: 'UPDATE',
-      details: `Updated transaction details for ${transaction.firstName} ${transaction.lastName}`,
+      details: activityDetails,
       resourceType: 'TRANSACTION',
       entityId: id,
-      userId: userId || transaction.userId
+      userId: userId || transaction.userId,
+      metadata: JSON.stringify({
+        totalExcessRefundAmount,
+        excessRefunds: excessRefunds || {},
+        hasExcessRefunds: totalExcessRefundAmount > 0
+      })
     }, { transaction: t });
 
     await t.commit();

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -191,19 +191,6 @@
       "integrity": "sha512-8/ZjHeUPe210Bt5oyaOIGx4h8lHdsQs19BiOT44gi/jBEgK7uBGA0Fy7NRsyh777al3m6WM0mBf0UR7xd4R7WQ==",
       "deprecated": "This package has been renamed to @simplewebauthn/types. Please install @simplewebauthn/types instead to ensure you receive future updates."
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
-    },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -601,57 +588,6 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/engine.io": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
-      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
-      "dependencies": {
-        "@types/cors": "^2.8.12",
-        "@types/node": ">=10.0.0",
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.7.2",
-        "cors": "~2.8.5",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
-      },
-      "engines": {
-        "node": ">=10.2.0"
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/es-define-property": {

--- a/frontend/src/components/transaction/IncomeTable.jsx
+++ b/frontend/src/components/transaction/IncomeTable.jsx
@@ -26,7 +26,7 @@ const TransactionRow = ({
       key={transaction.id} 
       className={transaction.status === 'cancelled' 
         ? 'bg-gray-100 text-gray-500' 
-        : getRefundedTestsInfo(transaction).count > 0 ? 'bg-red-50' : 'bg-white'
+        : 'bg-white'
       }
     >
       <td className="py-1 md:py-2 px-1 md:px-2 border border-green-200 sticky left-0 bg-inherit">
@@ -40,11 +40,6 @@ const TransactionRow = ({
         ) : (
           <span className={transaction.status === 'cancelled' ? 'line-through' : ''}>
             {transaction.id}
-            {getRefundedTestsInfo(transaction).count > 0 && (
-              <span className="ml-1 text-xs text-red-600 font-medium">
-                ({getRefundedTestsInfo(transaction).count} refunded: ₱{getRefundedTestsInfo(transaction).amount.toFixed(2)})
-              </span>
-            )}
           </span>
         )}
       </td>

--- a/frontend/src/hooks/transaction/useTransactionManagement.js
+++ b/frontend/src/hooks/transaction/useTransactionManagement.js
@@ -187,6 +187,21 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
           
           const freshTransaction = formatTransactionForDisplay(response.data.data, departments, currentReferrers);
           
+          // Restore excess refunds from metadata if they exist
+          if (response.data.data.metadata) {
+            try {
+              const metadata = typeof response.data.data.metadata === 'string' 
+                ? JSON.parse(response.data.data.metadata) 
+                : response.data.data.metadata;
+              
+              if (metadata.excessRefunds && typeof metadata.excessRefunds === 'object') {
+                setRefundAmounts(metadata.excessRefunds);
+              }
+            } catch (error) {
+              console.warn('Failed to parse transaction metadata:', error);
+            }
+          }
+          
           if (!freshTransaction.referrer || freshTransaction.referrer === 'Unknown' || freshTransaction.referrer === 'Out Patient') {
             freshTransaction.referrer = preservedInfo.referrer;
           }
@@ -252,12 +267,31 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
     setSelectedSummaryTransaction(null);
     setIsRefundMode(false);
     setSelectedRefunds({});
+    setRefundAmounts({}); // Clear excess refund amounts
   };
 
   // Enter edit mode for transaction summary
   const handleEnterEditMode = () => {
     // Create a deep copy of the transaction for editing
-    setEditedSummaryTransaction(JSON.parse(JSON.stringify(selectedSummaryTransaction)));
+    const editedTx = JSON.parse(JSON.stringify(selectedSummaryTransaction));
+    
+    // Auto-set 20% discount for PWD or Senior Citizen if not already set
+    const idType = (editedTx?.originalTransaction?.idType || '').trim().toLowerCase();
+    if (idType === 'person with disability' || idType === 'senior citizen') {
+      if (editedTx?.originalTransaction?.TestDetails) {
+        editedTx.originalTransaction.TestDetails.forEach(test => {
+          // Only set discount if it's not already set or is 0
+          if (!test.discountPercentage || test.discountPercentage === '0' || test.discountPercentage === 0) {
+            test.discountPercentage = '20';
+            // Recalculate discounted price
+            const originalPrice = parseFloat(test.originalPrice) || 0;
+            test.discountedPrice = (originalPrice * 0.8).toFixed(2);
+          }
+        });
+      }
+    }
+    
+    setEditedSummaryTransaction(editedTx);
     setIsEditingSummary(true);
   };
 
@@ -267,6 +301,7 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
     setEditedSummaryTransaction(null);
     setIsRefundMode(false);
     setSelectedRefunds({});
+    setRefundAmounts({}); // Clear excess refund amounts
   };
 
   // Handle changes to summary fields
@@ -450,8 +485,8 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
           discountedPrice: "0.00"  
         };
         
-        const originalPrice = parseFloat(test.originalPrice) || 0;
-        toast.info(`Test "${test.testName}" marked for refund (₱${originalPrice.toFixed(2)})`);
+        const discountedPrice = parseFloat(test.discountedPrice) || 0;
+        toast.info(`Test "${test.testName}" marked for refund (₱${discountedPrice.toFixed(2)})`);
         
         setEditedSummaryTransaction(updatedTransaction);
       }
@@ -520,61 +555,88 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
         return; 
       }
       
+      // Get the current discounted price - calculate it if needed
       const originalPrice = parseFloat(testCopy.originalPrice) || 0;
-      const discountedPrice = parseFloat(testCopy.discountedPrice) || 0;
+      let discountedPrice;
+      
+      // Calculate discounted price based on percentage or use stored value
+      const idType = (editedSummaryTransaction?.originalTransaction?.idType || '').trim().toLowerCase();
+      const isSpecialDiscount = idType === 'person with disability' || idType === 'senior citizen';
+      
+      if (isSpecialDiscount) {
+        // Apply 20% discount for PWD/Senior Citizen
+        const discountPercent = parseFloat(testCopy.discountPercentage || 20);
+        discountedPrice = originalPrice * (1 - discountPercent/100);
+      } else {
+        // Apply regular discount if any
+        const discountPercent = parseFloat(testCopy.discountPercentage || 0);
+        discountedPrice = originalPrice * (1 - discountPercent/100);
+      }
+      
+      // Store calculated discounted price
+      testCopy.discountedPrice = discountedPrice.toFixed(2);
+      
+      // Get current payment values
       const numValue = parseFloat(value) || 0;
       const otherField = field === 'cashAmount' ? 'gCashAmount' : 'cashAmount';
       const otherValue = parseFloat(testCopy[otherField]) || 0;
-      const totalPayment = numValue + otherValue;
       
-      const discountPercentage = parseInt(testCopy.discountPercentage) || 0;
-      if (discountPercentage === 0 && totalPayment > originalPrice) {
-        toast.error(`Total payment cannot exceed original price of ₱${originalPrice.toFixed(2)} when no discount is applied`);
-        return; 
-      }
-      
-      // Set the new value directly (no automatic adjustment)
-      testCopy[field] = value;
-      
-      // Calculate refund if payment exceeds price
-      const refundId = `test-${testCopy.testDetailId}`;
-      if (totalPayment > discountedPrice) {
-        const refundAmount = totalPayment - discountedPrice;
-        // Update refund tracking for this test
-        setRefundAmounts(prev => ({
-          ...prev,
-          [refundId]: refundAmount
-        }));
-        // Debounce the toast: only show after input is complete (onBlur or Enter)
-        if (window) {
-          if (window._refundToastTimeout) clearTimeout(window._refundToastTimeout);
-          window._refundToastTimeout = setTimeout(() => {
-            toast.info(`Payment exceeds price by ₱${refundAmount.toFixed(2)} - excess will be recorded as refund`);
-          }, 500);
+      // Enforce limits based on field - cap at discounted price
+      if (field === 'cashAmount') {
+        // For cash payments, limit to the discounted price
+        if (numValue > discountedPrice) {
+          testCopy[field] = discountedPrice.toFixed(2);
+        } else {
+          testCopy[field] = value;
         }
       } else {
-        setRefundAmounts(prev => {
-          const newRefunds = {...prev};
-          delete newRefunds[refundId];
-          return newRefunds;
-        });
+        // For GCash payments, limit to remaining amount after cash payment
+        const cashAmount = parseFloat(testCopy.cashAmount || 0);
+        const remainingAmount = Math.max(0, discountedPrice - cashAmount);
+        
+        if (numValue > remainingAmount) {
+          testCopy[field] = remainingAmount.toFixed(2);
+        } else {
+          testCopy[field] = value;
+        }
       }
+      
+      // Recalculate total payment after adjustments
+      const updatedCashAmount = parseFloat(testCopy.cashAmount || 0);
+      const updatedGCashAmount = parseFloat(testCopy.gCashAmount || 0);
+      const totalPayment = updatedCashAmount + updatedGCashAmount;
+      
+      // Clear any refund tracking since payments are now capped at discounted price
+      const refundId = `test-${testCopy.testDetailId}`;
+      setRefundAmounts(prev => {
+        const newRefunds = {...prev};
+        delete newRefunds[refundId];
+        return newRefunds;
+      });
       
       // Update balance - always based on actual calculation
       const newBalanceAmount = Math.max(0, discountedPrice - totalPayment).toFixed(2);
       testCopy.balanceAmount = newBalanceAmount;
     }
     else if (field === 'discountPercentage') {
-      // Only allow integer percentages from 0-100
-      if (value && !/^\d{0,3}$/.test(value)) {
-        return; 
-      }
-      
-      const percentValue = parseInt(value) || 0;
-      if (percentValue > 100) {
-        toast.warning('Discount cannot exceed 100%');
-        testCopy.discountPercentage = "100";
+      // Allow empty value for clearing the field
+      if (value === '') {
+        testCopy.discountPercentage = '';
+        // Reset to original price when no discount
+        const originalPrice = parseFloat(testCopy.originalPrice) || 0;
+        testCopy.discountedPrice = originalPrice.toFixed(2);
       } else {
+        // Only allow numeric input (0-9) and ensure it's a valid percentage
+        if (!/^\d{1,2}$|^100$/.test(value)) {
+          return; // Reject invalid input
+        }
+        
+        const percentValue = parseInt(value) || 0;
+        if (percentValue > 100) {
+          toast.warning('Discount cannot exceed 100%');
+          return;
+        }
+        
         testCopy.discountPercentage = value;
       }
       
@@ -584,35 +646,128 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
       const newDiscountedPrice = originalPrice * (1 - discountPercent/100);
       testCopy.discountedPrice = newDiscountedPrice.toFixed(2);
       
-      // Recalculate balance
-      const cashAmount = parseFloat(testCopy.cashAmount || 0);
-      const gCashAmount = parseFloat(testCopy.gCashAmount || 0);
-      const totalPayment = cashAmount + gCashAmount;
+      // Get current payment amounts
+      const currentCashAmount = parseFloat(testCopy.cashAmount || 0);
+      const currentGCashAmount = parseFloat(testCopy.gCashAmount || 0);
+      const totalPayment = currentCashAmount + currentGCashAmount;
       
-      // Check for potential refund if price is now less than payment
-      const refundId = `test-${testCopy.testDetailId}`;
+      // If discounted price is lower than total payments, cap the payments
       if (totalPayment > newDiscountedPrice) {
-        const refundAmount = totalPayment - newDiscountedPrice;
+        // Clear any refund tracking for this test
+        const refundId = `test-${testCopy.testDetailId}`;
+        setRefundAmounts(prev => {
+          const newRefunds = {...prev};
+          delete newRefunds[refundId];
+          return newRefunds;
+        });
+        
+        // Cap payments to match discounted price
+        if (totalPayment > 0) {
+          // Maintain the ratio between cash and GCash payments
+          const cashRatio = currentCashAmount / totalPayment;
+          const gCashRatio = currentGCashAmount / totalPayment;
+          
+          const newCashAmount = newDiscountedPrice * cashRatio;
+          const newGCashAmount = newDiscountedPrice * gCashRatio;
+          
+          testCopy.cashAmount = newCashAmount.toFixed(2);
+          testCopy.gCashAmount = newGCashAmount.toFixed(2);
+          
+          // Balance should be 0 since payments now match discounted price
+          testCopy.balanceAmount = "0.00";
+        } else {
+          // If no payments were made, just set balance to discounted price
+          testCopy.balanceAmount = newDiscountedPrice.toFixed(2);
+        }
+      } else {
+        // No overpayment, just recalculate balance normally
+        const refundId = `test-${testCopy.testDetailId}`;
+        setRefundAmounts(prev => {
+          const newRefunds = {...prev};
+          delete newRefunds[refundId];
+          return newRefunds;
+        });
+        
+        testCopy.balanceAmount = Math.max(0, newDiscountedPrice - totalPayment).toFixed(2);
+      }
+    }
+    else if (field === 'discountedPrice') {
+      // Allow direct editing of discounted price
+      const newDiscountedPrice = parseFloat(value) || 0;
+      const originalPrice = parseFloat(testCopy.originalPrice) || 0;
+      
+      // Validate that discounted price doesn't exceed original price
+      if (newDiscountedPrice > originalPrice) {
+        toast.warning('Discounted price cannot exceed original price');
+        return;
+      }
+      
+      testCopy.discountedPrice = value;
+      
+      // Recalculate discount percentage
+      if (originalPrice > 0) {
+        const discountPercent = Math.round(((originalPrice - newDiscountedPrice) / originalPrice) * 100);
+        testCopy.discountPercentage = Math.max(0, Math.min(100, discountPercent)).toString();
+      }
+      
+      // Get current payment amounts
+      const currentCashAmount = parseFloat(testCopy.cashAmount || 0);
+      const currentGCashAmount = parseFloat(testCopy.gCashAmount || 0);
+      const totalPayment = currentCashAmount + currentGCashAmount;
+      
+      // Clear any refund tracking for this test
+      const refundId = `test-${testCopy.testDetailId}`;
+      setRefundAmounts(prev => {
+        const newRefunds = {...prev};
+        delete newRefunds[refundId];
+        return newRefunds;
+      });
+      
+      // If payments exceed new discounted price, cap them
+      if (totalPayment > newDiscountedPrice) {
+        // Adjust cash and GCash proportionally to match discounted price
+        if (totalPayment > 0) {
+          const cashRatio = currentCashAmount / totalPayment;
+          const gCashRatio = currentGCashAmount / totalPayment;
+          
+          const newCashAmount = newDiscountedPrice * cashRatio;
+          const newGCashAmount = newDiscountedPrice * gCashRatio;
+          
+          testCopy.cashAmount = newCashAmount.toFixed(2);
+          testCopy.gCashAmount = newGCashAmount.toFixed(2);
+        }
+        
+        testCopy.balanceAmount = "0.00";
+      } else {
+        testCopy.balanceAmount = Math.max(0, newDiscountedPrice - totalPayment).toFixed(2);
+      }
+    }
+    else if (field === 'cashAmount' || field === 'gCashAmount') {
+      // Handle payment field changes with refund calculation
+      const newValue = parseFloat(value) || 0;
+      testCopy[field] = value;
+      
+      const cashAmount = field === 'cashAmount' ? newValue : parseFloat(testCopy.cashAmount || 0);
+      const gCashAmount = field === 'gCashAmount' ? newValue : parseFloat(testCopy.gCashAmount || 0);
+      const totalPayment = cashAmount + gCashAmount;
+      const discountedPrice = parseFloat(testCopy.discountedPrice) || 0;
+      
+      const refundId = `test-${testCopy.testDetailId}`;
+      if (totalPayment > discountedPrice) {
+        const refundAmount = totalPayment - discountedPrice;
         setRefundAmounts(prev => ({
           ...prev,
           [refundId]: refundAmount
         }));
-        // Debounce the toast: only show after input is complete (onBlur or Enter)
-        if (window) {
-          if (window._refundToastTimeout) clearTimeout(window._refundToastTimeout);
-          window._refundToastTimeout = setTimeout(() => {
-            toast.info(`Payment now exceeds discounted price by ₱${refundAmount.toFixed(2)} - excess will be recorded as refund`);
-          }, 500);
-        }
+        testCopy.balanceAmount = "0.00";
       } else {
         setRefundAmounts(prev => {
           const newRefunds = {...prev};
           delete newRefunds[refundId];
           return newRefunds;
         });
+        testCopy.balanceAmount = Math.max(0, discountedPrice - totalPayment).toFixed(2);
       }
-      
-      testCopy.balanceAmount = Math.max(0, newDiscountedPrice - totalPayment).toFixed(2);
     }
     else {
       // For other fields, just set the value
@@ -722,8 +877,7 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
         setIsEditingSummary(false);
         setEditedSummaryTransaction(null);
         setSelectedRefunds({});
-        
-        closeTransactionSummary();
+        setIsTransactionSummaryOpen(false);
       } else {
         console.error('Unexpected response format:', response);
         toast.error('Failed to save changes: Unexpected response format');
@@ -808,7 +962,8 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
       testDetails: testDetails,
       isRefundProcessing: isProcessingRefunds, 
       departmentRefunds: departmentRefunds, 
-      refundDate: new Date().toISOString() 
+      refundDate: new Date().toISOString(),
+      excessRefunds: refundAmounts || {},
     };
     
     // Validate before saving
@@ -848,6 +1003,10 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
     }
     
     return true;
+  };
+
+  const clearRefundAmounts = () => {
+    setRefundAmounts({});
   };
 
   return {
@@ -890,6 +1049,7 @@ export const useTransactionManagement = (user, selectedDate, departments, referr
     handleRefundSelection,
     handleTestDetailChange,
     handleSaveEdit,
+    clearRefundAmounts,
 
     // Mutations
     mutations: {

--- a/frontend/src/pages/Transaction.jsx
+++ b/frontend/src/pages/Transaction.jsx
@@ -111,6 +111,7 @@ const Transaction = () => {
     toggleRefundMode,
     handleTestDetailChange,
     handleSaveClick,
+    clearRefundAmounts,
     mutations,
     refundAmounts
   } = useTransactionManagement(user, selectedDate);
@@ -124,7 +125,8 @@ const Transaction = () => {
     );
   });
 
-  // Calculate department totals
+  // Calculate department totals with filtered transactions
+  const calculatedTotals = calculateDepartmentTotals(filteredTransactions);
   const departmentsWithValues = getDepartmentsWithValues();
   const { totalGross, totalGCash } = calculateTotalValues(filteredTransactions);
 
@@ -365,7 +367,9 @@ const Transaction = () => {
     handleCancelEdit,
     handleEnterEditMode,
     toggleRefundMode,
-    handleRefundSelection
+    handleRefundSelection,
+    clearRefundAmounts,
+    refundAmounts
   };
 
   const refundDisplay = (
@@ -427,7 +431,7 @@ const Transaction = () => {
           <IncomeTable
             filteredTransactions={filteredTransactions}
             departmentsWithValues={departmentsWithValues}
-            departmentTotals={departmentTotals}
+            departmentTotals={calculatedTotals.departmentTotals}
             totalGross={totalGross}
             editingId={editingId}
             editedTransaction={editedTransaction}
@@ -473,7 +477,7 @@ const Transaction = () => {
                       DEPOSIT
                     </td>
                     <td className="bg-gray-100 text-green-800 font-medium py-1 px-4 md:px-8 border border-gray-300 text-right">
-                      {Math.max(0, totalGross - totalGCash).toLocaleString(undefined, { 
+                      {Math.max(0, totalGross - totalRefundsToDisplay - totalGCash).toLocaleString(undefined, { 
                         minimumFractionDigits: 2, 
                         maximumFractionDigits: 2 
                       })}

--- a/frontend/src/utils/transactionUtils.js
+++ b/frontend/src/utils/transactionUtils.js
@@ -2,6 +2,7 @@
 export const isTestRefunded = (test) => {
   if (!test) return false;
   
+  // Primary check: explicit status
   if (test.status) {
     const status = test.status.toLowerCase();
     if (status === 'refunded' || status === 'refund') {
@@ -9,14 +10,17 @@ export const isTestRefunded = (test) => {
     }
   }
   
+  // Secondary check: explicit isRefunded flag
   if (test.isRefunded === true) {
     return true;
   }
   
+  // Tertiary check: discounted price is 0 but original price exists (common refund indicator)
   if (parseFloat(test.discountedPrice) === 0 && parseFloat(test.originalPrice) > 0) {
     return true;
   }
   
+  // Additional check: any refund-related property set to true
   for (const key in test) {
     if (key.toLowerCase().includes('refund') && test[key] === true) {
       return true;
@@ -35,7 +39,34 @@ export const getRefundedTestsInfo = (transaction) => {
   transaction.originalTransaction.TestDetails.forEach(test => {
     if (test.status === 'refunded') {
       count++;
-      amount += parseFloat(test.originalPrice || test.discountedPrice) || 0;
+      
+      // Calculate proper refund amount based on discounts
+      let refundAmount;
+      
+      // Check if this is a PWD or Senior Citizen transaction
+      const idType = (transaction.originalTransaction?.idType || '').trim().toLowerCase();
+      const isSpecialDiscount = idType === 'person with disability' || idType === 'senior citizen';
+      
+      if (isSpecialDiscount) {
+        // For PWD/Senior Citizens, always calculate with 20% discount
+        if (test.discountedPrice && parseFloat(test.discountedPrice) > 0) {
+          refundAmount = parseFloat(test.discountedPrice);
+        } else {
+          // Calculate 20% discount from original price
+          const originalPrice = parseFloat(test.originalPrice || 0);
+          refundAmount = originalPrice * 0.8;
+        }
+      } else if (test.discountPercentage && parseFloat(test.discountPercentage) > 0) {
+        // For regular discount, calculate based on percentage
+        const originalPrice = parseFloat(test.originalPrice || 0);
+        const discountPercent = parseFloat(test.discountPercentage);
+        refundAmount = originalPrice * (1 - discountPercent/100);
+      } else {
+        // Default fallback
+        refundAmount = parseFloat(test.discountedPrice || test.originalPrice) || 0;
+      }
+      
+      amount += refundAmount;
     }
   });
   
@@ -82,6 +113,7 @@ export const formatTransactionForDisplay = (transaction, departments = [], refer
     grossDeposit = transaction.TestDetails
       .filter(test => test && test.status !== 'refunded')
       .reduce((sum, test) => {
+        // Always use discountedPrice which includes any discounts (including PWD/Senior 20%)
         const testPrice = parseFloat(test.discountedPrice) || 0;
         const balanceAmount = parseFloat(test.balanceAmount) || 0;
         return sum + (testPrice - balanceAmount);
@@ -109,13 +141,55 @@ export const calculateRefundTotal = (filteredTransactions) => {
   let refundedTestCount = 0;
   
   filteredTransactions.forEach(transaction => {
+    // Skip refunded tests from cancelled transactions
+    if (transaction.status === 'cancelled') return;
+    
     if (!transaction.originalTransaction?.TestDetails) return;
     
     transaction.originalTransaction.TestDetails.forEach(test => {
       if (isTestRefunded(test)) {
         refundedTestCount++;
         
-        const refundAmount = parseFloat(test.originalPrice || test.discountedPrice) || 0;
+        // Calculate refund amount based on what was actually paid (discounted price)
+        // This ensures we capture the full refund amount regardless of payment method (cash/GCash)
+        let refundAmount;
+        
+        // First check if this is a PWD or Senior Citizen transaction
+        const idType = (transaction.originalTransaction?.idType || '').trim().toLowerCase();
+        const isSpecialDiscount = idType === 'person with disability' || idType === 'senior citizen';
+        
+        if (isSpecialDiscount) {
+          // For PWD/Senior Citizens, use discounted price which already includes 20% discount
+          if (test.discountedPrice && parseFloat(test.discountedPrice) > 0) {
+            refundAmount = parseFloat(test.discountedPrice);
+          } else {
+            // Calculate 20% discounted price from original price as fallback
+            const originalPrice = parseFloat(test.originalPrice || 0);
+            refundAmount = originalPrice * 0.8; // Apply 20% discount
+          }
+        } else if (test.discountPercentage && parseFloat(test.discountPercentage) > 0) {
+          // For tests with custom discount percentages, calculate based on that
+          const originalPrice = parseFloat(test.originalPrice || 0);
+          const discountPercent = parseFloat(test.discountPercentage);
+          refundAmount = originalPrice * (1 - discountPercent/100);
+        } else {
+          // For regular tests, use discounted price (which is the actual amount paid)
+          // This covers both cash and GCash payments equally
+          refundAmount = parseFloat(test.discountedPrice || test.originalPrice) || 0;
+        }
+        
+        // Alternative calculation: if we have payment information, use the sum of all payments
+        // This ensures we capture the actual refund amount for tests paid with any combination of cash/GCash
+        const cashAmount = parseFloat(test.cashAmount || 0);
+        const gCashAmount = parseFloat(test.gCashAmount || 0);
+        const totalPaid = cashAmount + gCashAmount;
+        
+        // Use the higher of calculated refund amount or total paid amount
+        // This ensures we don't miss any refunds, especially for GCash payments
+        if (totalPaid > 0 && totalPaid > refundAmount) {
+          refundAmount = totalPaid;
+        }
+        
         totalRefundAmount += refundAmount;
       }
     });


### PR DESCRIPTION
# 🌟 What's Included?
- Saved the Transaction with totalIncome discounted by 20% due to idType discount from FE to BE
- Use the Transaction Summary Modal Reusable Component on Add Transaction
- Add Total Transation Row on Transaction Summary Modal 
- Fix Gross it now Records the Updated Discount if id type is Senior Citizen and Person with Disability on Income Table
- Fix Transaction Summary Modal total not updating. if a test is refunded it should exclude it on the total cashpaid and gcash paid 
- Fix Deposit now includes Refund on calculation
- Fix Canceled Transaction that has refunded test are no longer calculated on refund display on transactionUtils.js
- Fix Income Total Table Calculation
- Fix if a test has a balance it should deduct it on the total.
- Fix the total cash paid should only calculate the cash paids
- Fix the total gcash paid should only calculate the gcash paids
- Fix if the discounted percentag make the discounted price exceeded the cash paid and gcash paid it makes it the same