### PR TITLE
Fix: Update .gitignore to allow .env.example tracking

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 .env
 .env.local
-.env-example
 


### PR DESCRIPTION
- Remove .env.example from .gitignore to allow it to be tracked
- This ensures the example environment file is available for reference