### PR TITLE
Fix: Add getter/setter for credentialPublicKey BYTEA handling

### DIFF
--- a/backend/migrations/20250113000001-fix-authenticator-credentialpublickey-type.js
+++ b/backend/migrations/20250113000001-fix-authenticator-credentialpublickey-type.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // First, clear all authenticators (they have corrupted data)
+    await queryInterface.bulkDelete('Authenticators', {}, {});
+
+    // Then alter the column type to BYTEA for PostgreSQL
+    await queryInterface.changeColumn('Authenticators', 'credentialPublicKey', {
+      type: Sequelize.BLOB,
+      allowNull: false
+    });
+
+    console.log('Fixed credentialPublicKey column type and cleared authenticators');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // Cannot revert
+    console.log('Cannot revert credentialPublicKey type change');
+  }
+};

--- a/backend/models/Authenticator.js
+++ b/backend/models/Authenticator.js
@@ -17,7 +17,29 @@ const Authenticator = sequelize.define('Authenticator', {
   },
   credentialPublicKey: {
     type: DataTypes.BLOB,
-    allowNull: false
+    allowNull: false,
+    get() {
+      const value = this.getDataValue('credentialPublicKey');
+      // Ensure it's always returned as Buffer
+      if (Buffer.isBuffer(value)) {
+        return value;
+      }
+      if (typeof value === 'string') {
+        // If stored as hex string (PostgreSQL BYTEA format), convert to Buffer
+        return Buffer.from(value, 'hex');
+      }
+      return value;
+    },
+    set(value) {
+      // Store as Buffer
+      if (Buffer.isBuffer(value)) {
+        this.setDataValue('credentialPublicKey', value);
+      } else if (typeof value === 'string') {
+        this.setDataValue('credentialPublicKey', Buffer.from(value, 'base64'));
+      } else {
+        this.setDataValue('credentialPublicKey', value);
+      }
+    }
   },
   counter: {
     type: DataTypes.INTEGER,


### PR DESCRIPTION
Critical fix for PostgreSQL BYTEA column handling:
- Add explicit getter to handle credentialPublicKey as Buffer or hex string
- Add explicit setter to ensure credentialPublicKey is stored as Buffer
- Add migration to clear corrupted authenticators and ensure BYTEA type
- This resolves CBOR decoding errors during authentication

PostgreSQL stores BYTEA as hex strings, but SimpleWebAuthn expects Buffer. The getter/setter ensures proper conversion in both directions.