### PR TITLE
Add: Include Reimbursed, Cancelled and remove refunded on Dashboard C…

### DIFF
--- a/backend/controllers/dashboardController.js
+++ b/backend/controllers/dashboardController.js
@@ -59,7 +59,7 @@ const dashboardController = {
         ],
         where: {
           status: {
-            [Op.notIn]: ['paid', 'refunded']
+            [Op.notIn]: ['paid', 'reimbursed', 'cancelled']
           }
         }
       });
@@ -305,7 +305,7 @@ const dashboardController = {
         ],
         where: {
           status: {
-            [Op.notIn]: ['paid', 'refunded']
+            [Op.notIn]: ['paid', 'reimbursed', 'cancelled']
           }
         }
       });
@@ -345,7 +345,7 @@ const dashboardController = {
         ],
         where: {
           status: {
-            [Op.notIn]: ['paid', 'refunded']
+            [Op.notIn]: ['paid', 'reimbursed', 'cancelled']
           }
         },
         group: [
@@ -462,7 +462,7 @@ const dashboardController = {
           ],
           where: {
             status: {
-              [Op.notIn]: ['paid', 'refunded']
+              [Op.notIn]: ['paid', 'reimbursed', 'cancelled']
             }
           }
         });


### PR DESCRIPTION
Updates the filtering logic in the `dashboardController` to exclude additional statuses from certain queries. Specifically, it now excludes records with statuses `'reimbursed'` and `'cancelled'` in addition to the previously excluded `'paid'` and `'refunded'` statuses. This change ensures that these statuses are consistently omitted from relevant dashboard queries.

**Filtering logic improvements:**

* Updated all relevant queries in `dashboardController.js` to exclude records with statuses `'reimbursed'` and `'cancelled'`, in addition to `'paid'` and `'refunded'`, by modifying the `[Op.notIn]` arrays in the `where` clauses. 