### PR TITLE
Fix: Hidden Permissions and z-10 Index Logout Problem

### DIFF
--- a/backend/schema/updates/002_rbac_tables.sql
+++ b/backend/schema/updates/002_rbac_tables.sql
@@ -88,31 +88,20 @@ INSERT INTO `Permissions` (`permissionKey`, `displayName`, `description`, `categ
 ('referrals.view', 'View Referrals', 'View referral records', 'Referrals', NOW(), NOW()),
 ('referrals.export', 'Export Referrals', 'Export referral data', 'Referrals', NOW(), NOW()),
 
--- Reports
-('reports.monthly', 'View Monthly Reports', 'Access to monthly income and expense reports', 'Reports', NOW(), NOW()),
-('reports.export', 'Export Reports', 'Export report data to Excel/PDF', 'Reports', NOW(), NOW()),
-
 -- User Accounts & Administration
 ('accounts.manage', 'Manage User Accounts', 'View, create, edit, and archive user accounts', 'Administration', NOW(), NOW()),
 ('referrals.manage', 'Manage Referrers', 'Add, edit, and archive referrers', 'Administration', NOW(), NOW()),
 
 -- Roles & Permissions
-('roles.view', 'View Roles', 'View roles and their permissions', 'Administration', NOW(), NOW()),
 ('roles.manage', 'Manage Roles', 'Create, edit, and delete roles and assign permissions', 'Administration', NOW(), NOW()),
-
--- Settings
-('settings.view', 'View Settings', 'Access to view application settings', 'Settings', NOW(), NOW()),
-('settings.edit', 'Edit Settings', 'Modify application settings', 'Settings', NOW(), NOW()),
 
 -- Activity Logs
 ('activitylog.view', 'View Activity Logs', 'View system activity logs', 'Administration', NOW(), NOW()),
 
 -- Department Management
-('departments.view', 'View Departments', 'View department list', 'Administration', NOW(), NOW()),
 ('departments.manage', 'Manage Departments', 'Create, edit, and delete departments', 'Administration', NOW(), NOW()),
 
 -- Test Management
-('tests.view', 'View Tests', 'View test list', 'Administration', NOW(), NOW()),
 ('tests.manage', 'Manage Tests', 'Create, edit, and delete tests', 'Administration', NOW(), NOW())
 ON DUPLICATE KEY UPDATE `displayName` = VALUES(`displayName`);
 
@@ -136,11 +125,9 @@ FROM Permissions p
 WHERE p.permissionKey IN (
   'dashboard.view',
   'transactions.view', 'transactions.create', 'transactions.edit', 'transactions.export',
-  'collectible.view', 'collectible.create', 'collectible.edit', 'collectible.export',
+  'collectible.view', 'collectible.create', 'collectible.edit',
   'expenses.view', 'expenses.create', 'expenses.edit', 'expenses.export',
-  'referrals.view', 'referrals.export',
-  'reports.monthly', 'reports.export',
-  'settings.view'
+  'referrals.view', 'referrals.export'
 )
 ON DUPLICATE KEY UPDATE `updatedAt` = NOW();
 

--- a/backend/schema/updates/003_remove_unused_permissions.sql
+++ b/backend/schema/updates/003_remove_unused_permissions.sql
@@ -1,0 +1,40 @@
+-- =====================================================
+-- Remove unused/deprecated permissions
+-- Run this on your database to clean up
+-- =====================================================
+
+-- First remove any RolePermission assignments for these permissions
+DELETE rp FROM `RolePermissions` rp
+INNER JOIN `Permissions` p ON rp.permissionId = p.permissionId
+WHERE p.permissionKey IN (
+  'reports.export',
+  'reports.monthly',
+  'settings.edit',
+  'settings.view',
+  'expenses.archive',
+  'collectible.export',
+  'departments.view',
+  'roles.view',
+  'tests.view',
+  'accounts.view',
+  'accounts.create',
+  'accounts.edit',
+  'accounts.archive'
+);
+
+-- Then delete the permissions themselves
+DELETE FROM `Permissions` WHERE permissionKey IN (
+  'reports.export',
+  'reports.monthly',
+  'settings.edit',
+  'settings.view',
+  'expenses.archive',
+  'collectible.export',
+  'departments.view',
+  'roles.view',
+  'tests.view',
+  'accounts.view',
+  'accounts.create',
+  'accounts.edit',
+  'accounts.archive'
+);

--- a/frontend/src/components/auth/ProtectedRoute.jsx
+++ b/frontend/src/components/auth/ProtectedRoute.jsx
@@ -10,7 +10,7 @@ import 'react-toastify/dist/ReactToastify.css'
  * 
  * Props:
  * - component: Component to render if authorized
- * - requiredPermission: Single permission required (e.g., 'accounts.view')
+ * - requiredPermission: Single permission required (e.g., 'accounts.manage')
  * - requiredAnyPermission: Array of permissions, user needs at least one
  * - restrictFromRole: Legacy support - restrict specific role (deprecated)
  */

--- a/frontend/src/components/dashboard/LogoutConfirmModal.jsx
+++ b/frontend/src/components/dashboard/LogoutConfirmModal.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { LogOut, X } from 'lucide-react';
 
 const LogoutConfirmModal = ({ isOpen, onClose, onConfirm }) => {
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999] p-4">
       <div className="bg-white rounded-lg shadow-lg max-w-md w-full">
         <div className="bg-red-600 rounded-t-lg text-white p-4 flex justify-between items-center">
           <div className="flex items-center">
@@ -42,7 +43,8 @@ const LogoutConfirmModal = ({ isOpen, onClose, onConfirm }) => {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/frontend/src/components/settings/RoleManagement.jsx
+++ b/frontend/src/components/settings/RoleManagement.jsx
@@ -46,35 +46,10 @@ const RoleManagement = () => {
         try {
             const response = await roleAPI.getAllPermissions();
             if (response.data?.success) {
-                // Filter out permissions that should not be available for custom roles
-                const hiddenPermissions = [
-                    'reports.export',   // Export Reports - redundant
-                    'reports.monthly',  // View Monthly Reports - redundant
-                    'settings.edit',    // Edit Settings - not used
-                    'settings.view',    // View Settings - not used
-                    'expenses.archive', // Archive Expenses - not used
-                    'collectible.export', // Export Collectible Income - not used
-                    'departments.view', // View Departments - covered by manage functions
-                    'roles.view',       // View Roles - covered by manage functions
-                    'tests.view',       // View Tests - covered by manage functions
-                    'accounts.view',    // Old - replaced by accounts.manage
-                    'accounts.create',  // Old - replaced by accounts.manage
-                    'accounts.edit',    // Old - replaced by accounts.manage
-                    'accounts.archive'  // Old - replaced by accounts.manage
-                ];
-                
-                const filteredPermissions = {};
-                Object.entries(response.data.permissions).forEach(([category, perms]) => {
-                    const filteredPerms = perms.filter(p => !hiddenPermissions.includes(p.permissionKey));
-                    if (filteredPerms.length > 0) {
-                        filteredPermissions[category] = filteredPerms;
-                    }
-                });
-                
-                setPermissions(filteredPermissions);
+                setPermissions(response.data.permissions);
                 // Expand all categories by default
                 const expanded = {};
-                Object.keys(filteredPermissions).forEach(cat => {
+                Object.keys(response.data.permissions).forEach(cat => {
                     expanded[cat] = true;
                 });
                 setExpandedCategories(expanded);

--- a/frontend/src/hooks/auth/usePermissions.js
+++ b/frontend/src/hooks/auth/usePermissions.js
@@ -200,26 +200,22 @@ function getFallbackPermissions(role) {
     const adminPermissions = [
         'dashboard.view',
         'transactions.view', 'transactions.create', 'transactions.edit', 'transactions.cancel', 'transactions.refund', 'transactions.export',
-        'collectible.view', 'collectible.create', 'collectible.edit', 'collectible.export',
-        'expenses.view', 'expenses.create', 'expenses.edit', 'expenses.archive', 'expenses.export',
+        'collectible.view', 'collectible.create', 'collectible.edit',
+        'expenses.view', 'expenses.create', 'expenses.edit', 'expenses.export',
         'referrals.view', 'referrals.manage', 'referrals.export',
-        'reports.monthly', 'reports.export',
         'accounts.manage',
-        'roles.view', 'roles.manage',
-        'settings.view', 'settings.edit',
+        'roles.manage',
         'activitylog.view',
-        'departments.view', 'departments.manage',
-        'tests.view', 'tests.manage'
+        'departments.manage',
+        'tests.manage'
     ];
 
     const receptionistPermissions = [
         'dashboard.view',
         'transactions.view', 'transactions.create', 'transactions.edit', 'transactions.cancel', 'transactions.export',
-        'collectible.view', 'collectible.create', 'collectible.edit', 'collectible.export',
+        'collectible.view', 'collectible.create', 'collectible.edit',
         'expenses.view', 'expenses.create', 'expenses.edit', 'expenses.export',
-        'referrals.view', 'referrals.export',
-        'reports.monthly', 'reports.export',
-        'settings.view'
+        'referrals.view', 'referrals.export'
     ];
 
     if (role === 'admin') {


### PR DESCRIPTION
Unused permissions from both the backend and frontend, streamlining the role and permission management system. The changes ensure that only relevant permissions are available for use, and update all related logic to reflect this cleanup. This will help reduce confusion and prevent assignment of obsolete permissions.

**RBAC permission cleanup:**

* Removed multiple unused or deprecated permissions from the `Permissions` table, including report, settings, account, department, test, and export permissions. 
* Updated the permission assignment logic to exclude removed permissions from role default permissions. 

**Frontend permission logic updates:**

* Updated fallback permission lists for roles (admin, receptionist) to remove deprecated permissions, ensuring only current permissions are used in authentication and authorization checks. 
* Simplified permission filtering in the role management UI by no longer filtering hidden permissions on the frontend, as the backend now only provides relevant permissions. 
* Updated documentation comment to reference the new permission key (`accounts.manage`) instead of the removed `accounts.view`. 

**UI improvement:**

* Updated the logout confirmation modal to use React portals for better overlay handling and raised z-index for improved visibility. 